### PR TITLE
Update build.sh

### DIFF
--- a/Tradovate.WebSocket/build.sh
+++ b/Tradovate.WebSocket/build.sh
@@ -12,7 +12,7 @@ echo "[INFO] Copy DLLs to the 'bin' folder"
 mkdir -p bin;
 cp packages/Newtonsoft.Json.10.0.3/lib/net45/Newtonsoft.Json.dll bin/Newtonsoft.Json.dll;
 cp packages/RestSharp.105.1.0/lib/net45/RestSharp.dll bin/RestSharp.dll;
-cp packages/Websocket4Net.0.15.1/lib/net45/Websocket4Net.dll bin/Websocket4Net.dll;
+cp packages/WebSocket4Net.0.15.1/lib/net45/Websocket4Net.dll bin/WebSocket4Net.dll;
 cp packages/SuperSocket.ClientEngine.Core.0.9.0/lib/net45/SuperSocket.ClientEngine.dll bin/SuperSocket.ClientEngine.dll
 
 echo "[INFO] Run 'mcs' to build bin/Tradovate.WebSocket.dll"


### PR DESCRIPTION
WebSocket4Net is misspelled twice and causes the build to fail. The correct one is with UpperCase "S"